### PR TITLE
Fix api-version for 1.20

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: ${project.name}
 main: ${project.groupId}.coordinatesobfuscator.CoordinatesObfuscator
 version: ${project.version}
-api-version: 1.20
+api-version: "1.20"
 author: Cavallium
 depend: [ ProtocolLib ]
 folia-supported: true


### PR DESCRIPTION
API version 1.20 needs quotes to prevent being parsed as a decimal "1.2".

```
[21:13:36] [Server thread/ERROR]: [ModernPluginLoadingStrategy] Could not load plugin 'CoordinatesObfuscator-1.4.13.jar' in folder 'plugins'
org.bukkit.plugin.InvalidPluginException: Unsupported API version 1.2
	at org.bukkit.craftbukkit.v1_20_R1.util.CraftMagicNumbers.checkSupported(CraftMagicNumbers.java:380) ~[paper-1.20.1.jar:git-Paper-60]
```